### PR TITLE
Support bundled plugins in uploaded zip

### DIFF
--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
@@ -33,6 +33,11 @@ if [ "$TEST_TYPE" != "simple" ]; then
     fi
 
     sed -i -e "s|$TEST_ID.jmx|$JMETER_SCRIPT|g" test.json
+
+    # copy bundled plugin jars to jmeter extenstion folder to make them available to jmeter
+    JMETER_EXT_PATH=`find ~/.bzt/jmeter-taurus -type d -name "ext"`
+    BUNDLED_PLUGIN_DIR=`find $PWD -type d -name "plugins"`
+    cp -v $BUNDLED_PLUGIN_DIR/*.jar $JMETER_EXT_PATH
   fi
 fi
 

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
@@ -35,7 +35,7 @@ if [ "$TEST_TYPE" != "simple" ]; then
     sed -i -e "s|$TEST_ID.jmx|$JMETER_SCRIPT|g" test.json
 
     # copy bundled plugin jars to jmeter extension folder to make them available to jmeter
-    BUNDLED_PLUGIN_DIR=`find $PWD -maxdepth 1 -type d -name "plugins"`
+    BUNDLED_PLUGIN_DIR=`find $PWD -type d -name "plugins" | head -n 1`
     # attempt to copy only if a /plugins folder is present in upload
     if [ -z "$BUNDLED_PLUGIN_DIR" ]; then
       echo "skipping plugin installation (no /plugins folder in upload)"

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
@@ -35,7 +35,7 @@ if [ "$TEST_TYPE" != "simple" ]; then
     sed -i -e "s|$TEST_ID.jmx|$JMETER_SCRIPT|g" test.json
 
     # copy bundled plugin jars to jmeter extension folder to make them available to jmeter
-    BUNDLED_PLUGIN_DIR=`find $PWD -type d -name "plugins"`
+    BUNDLED_PLUGIN_DIR=`find $PWD -maxdepth 1 -type d -name "plugins"`
     # attempt to copy only if a /plugins folder is present in upload
     if [ -z "$BUNDLED_PLUGIN_DIR" ]; then
       echo "skipping plugin installation (no /plugins folder in upload)"

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
@@ -34,10 +34,21 @@ if [ "$TEST_TYPE" != "simple" ]; then
 
     sed -i -e "s|$TEST_ID.jmx|$JMETER_SCRIPT|g" test.json
 
-    # copy bundled plugin jars to jmeter extenstion folder to make them available to jmeter
-    JMETER_EXT_PATH=`find ~/.bzt/jmeter-taurus -type d -name "ext"`
+    # copy bundled plugin jars to jmeter extension folder to make them available to jmeter
     BUNDLED_PLUGIN_DIR=`find $PWD -type d -name "plugins"`
-    cp -v $BUNDLED_PLUGIN_DIR/*.jar $JMETER_EXT_PATH
+    # attempt to copy only if a /plugins folder is present in upload
+    if [ -z "$BUNDLED_PLUGIN_DIR" ]; then
+      echo "skipping plugin installation (no /plugins folder in upload)"
+    else
+      # ensure the jmeter extensions folder exists
+      JMETER_EXT_PATH=`find ~/.bzt/jmeter-taurus -type d -name "ext"`
+      if [ -z "$JMETER_EXT_PATH" ]; then
+        # fail fast - if plugins bundled they will be needed for the tests
+        echo "jmeter extension path (~/.bzt/jmeter-taurus/**/ext) not found - cannot install bundled plugins"
+        exit 1
+      fi
+      cp -v $BUNDLED_PLUGIN_DIR/*.jar $JMETER_EXT_PATH
+    fi
   fi
 fi
 


### PR DESCRIPTION
**Issue** #19

**Description of changes:**
Support for bundling plugins with the jmeter script.

Any .jar files included in a `/plugins` subdirectory within the uploaded
zip are copied to the jmeter extensions directory. They will be
available for the load test execution.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
