### PR TITLE
Enabled bucket policy for logging S3 bucket to allow secure transport only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2022-03-31
+
+### Added
+
+- Enabled encryption in transit for the logging S3 bucket.
+
 ## [2.0.1] - 2021-12-13
 
 Version 2.0.1 supports upgrading from version 2.0.0 but not from version 1.3.0 and below
@@ -58,14 +64,14 @@ Version 2.0.0 does not support upgrading from previous versions.
   - Added StartedBy tag to tasks for use by task listing functions
   - Modified all ECS task listing functions to support listing 1000 tasks
   - Modified TaskRunning lambda function to support being called multiple times from step functions
-- Tests start simultaneously 
+- Tests start simultaneously
   - Added ecscontroller.py to container package
   - Added ecslistener.py to container package
   - TaskRunner lambda launches worker tasks first, then leader task once workers are running
 - Run tests concurrently
   - Removed disabling of submit buttons if there is a test running
   - Unbuffered bzt output and added test Id to CloudWatch logs for access to test specific logs
-- Added support for Docker Hub login 
+- Added support for Docker Hub login
   - Added Secrets manager parameter to include secret containing Docker Hub credentials
 - Included more metrics
   - Added virtual users, failures, and successes to graph

--- a/source/infrastructure/test/__snapshots__/common-resources.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/common-resources.test.ts.snap
@@ -191,10 +191,6 @@ Object {
               "id": "W35",
               "reason": "This is the logging bucket, it does not require logging.",
             },
-            Object {
-              "id": "W51",
-              "reason": "Since the bucket does not allow the public access, it does not require to have bucket policy.",
-            },
           ],
         },
       },
@@ -224,6 +220,53 @@ Object {
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "TestCommonResourcesLogsBucketPolicyAB18A08E": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "TestCommonResourcesLogsBucket5B4DBD4F",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "TestCommonResourcesLogsBucket5B4DBD4F",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "TestCommonResourcesLogsBucket5B4DBD4F",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "TestCommonResourcesUUIDFDB821D1": Object {
       "DeletionPolicy": "Delete",

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
@@ -1968,10 +1968,6 @@ Object {
               "id": "W35",
               "reason": "This is the logging bucket, it does not require logging.",
             },
-            Object {
-              "id": "W51",
-              "reason": "Since the bucket does not allow the public access, it does not require to have bucket policy.",
-            },
           ],
         },
       },
@@ -2007,6 +2003,53 @@ Object {
       },
       "Type": "AWS::S3::Bucket",
       "UpdateReplacePolicy": "Retain",
+    },
+    "DLTCommonResourcesLogsBucketPolicyAA7FFB37": Object {
+      "Properties": Object {
+        "Bucket": Object {
+          "Ref": "DLTCommonResourcesLogsBucket48A2774D",
+        },
+        "PolicyDocument": Object {
+          "Statement": Array [
+            Object {
+              "Action": "s3:*",
+              "Condition": Object {
+                "Bool": Object {
+                  "aws:SecureTransport": "false",
+                },
+              },
+              "Effect": "Deny",
+              "Principal": Object {
+                "AWS": "*",
+              },
+              "Resource": Array [
+                Object {
+                  "Fn::GetAtt": Array [
+                    "DLTCommonResourcesLogsBucket48A2774D",
+                    "Arn",
+                  ],
+                },
+                Object {
+                  "Fn::Join": Array [
+                    "",
+                    Array [
+                      Object {
+                        "Fn::GetAtt": Array [
+                          "DLTCommonResourcesLogsBucket48A2774D",
+                          "Arn",
+                        ],
+                      },
+                      "/*",
+                    ],
+                  ],
+                },
+              ],
+            },
+          ],
+          "Version": "2012-10-17",
+        },
+      },
+      "Type": "AWS::S3::BucketPolicy",
     },
     "DLTCommonResourcesUUID2FD025A2": Object {
       "DeletionPolicy": "Delete",


### PR DESCRIPTION
**Issue #, if available:**
<!-- If there're any related issues, please add the issue number here. -->
#89 


**Description of changes:**
<!-- Please describe the changes you made -->
This PR only includes to add a bucket policy for logging S3 bucket for encryption in transit.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
