### PR TITLE
Update to version 3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.1] - 2022-11-18
+
+### Fixed
+
+- Bug fix for [#111](https://github.com/aws-solutions/distributed-load-testing-on-aws/issues/111) where a CloudFormation bug would occasionally cause deployments to fail.
+
 ## [3.1.0] - 2022-11-10
 
 ### Added

--- a/source/infrastructure/lib/testing-resources/real-time-data.ts
+++ b/source/infrastructure/lib/testing-resources/real-time-data.ts
@@ -73,9 +73,12 @@ export class RealTimeDataConstruct extends Construct {
       }]
     });
 
-    props.ecsCloudWatchLogGroup.addSubscriptionFilter('ECSLogSubscriptionFilter', {
+    const ecsCloudWatchSubscriptionFilter = props.ecsCloudWatchLogGroup.addSubscriptionFilter('ECSLogSubscriptionFilter', {
       destination: new LambdaDestination(realTimeDataPublisher),
       filterPattern: FilterPattern.allTerms("INFO: Current:", "live=true")
     });
+    const subscriptionFilterPermission = ecsCloudWatchSubscriptionFilter.node.findChild("CanInvokeLambda");
+    if(subscriptionFilterPermission != null)
+      ecsCloudWatchSubscriptionFilter.node.addDependency(subscriptionFilterPermission);
   }
 }

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-regional.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-regional.test.ts.snap
@@ -455,6 +455,9 @@ Object {
       "UpdateReplacePolicy": "Retain",
     },
     "DLTRegionalFargateDLTCloudWatchLogsGroupECSLogSubscriptionFilter018E070A": Object {
+      "DependsOn": Array [
+        "DLTRegionalFargateDLTCloudWatchLogsGroupECSLogSubscriptionFilterCanInvokeLambda20B8ED69",
+      ],
       "Properties": Object {
         "DestinationArn": Object {
           "Fn::GetAtt": Array [

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
@@ -3373,6 +3373,9 @@ Object {
       "UpdateReplacePolicy": "Delete",
     },
     "DLTEcsDLTCloudWatchLogsGroupECSLogSubscriptionFilterC5BB4DB5": Object {
+      "DependsOn": Array [
+        "DLTEcsDLTCloudWatchLogsGroupECSLogSubscriptionFilterCanInvokeLambdaF6EFF73B",
+      ],
       "Properties": Object {
         "DestinationArn": Object {
           "Fn::GetAtt": Array [

--- a/source/infrastructure/test/__snapshots__/real-time-data.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/real-time-data.test.ts.snap
@@ -107,6 +107,9 @@ Object {
       "UpdateReplacePolicy": "Retain",
     },
     "TestLogsGroupECSLogSubscriptionFilterBFBFAB24": Object {
+      "DependsOn": Array [
+        "TestLogsGroupECSLogSubscriptionFilterCanInvokeLambdaD7381D91",
+      ],
       "Properties": Object {
         "DestinationArn": Object {
           "Fn::GetAtt": Array [


### PR DESCRIPTION
## [3.1.1] - 2022-11-18

### Fixed

- Bug fix for [#111](https://github.com/aws-solutions/distributed-load-testing-on-aws/issues/111) where a CloudFormation bug would occasionally cause deployments to fail.