### PR TITLE
fix: typo in test

### DIFF
--- a/source/api-services/lib/metrics/index.spec.js
+++ b/source/api-services/lib/metrics/index.spec.js
@@ -21,7 +21,7 @@ describe("#SEND METRICS", () => {
     let mock = new MockAdapter(axios);
     mock.onPost().reply(200, {});
 
-    let response = await lambda.send({ taskCount: _taskCount, testType: "jmter", fileType: "zip" });
+    let response = await lambda.send({ taskCount: _taskCount, testType: "jmeter", fileType: "zip" });
     expect(response).toEqual(200);
   });
 
@@ -29,7 +29,7 @@ describe("#SEND METRICS", () => {
     let mock = new MockAdapter(axios);
     mock.onPost().reply(200, {});
 
-    let response = await lambda.send({ taskCount: _taskCount, testType: "jemter" });
+    let response = await lambda.send({ taskCount: _taskCount, testType: "jmeter" });
     expect(response).toEqual(200);
   });
 


### PR DESCRIPTION
**Description of changes:**
This spell `jmeter` correctly

**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
