### PR TITLE
Do more cleanup on delete

### DIFF
--- a/scripts/list-orphaned-assets.sh
+++ b/scripts/list-orphaned-assets.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+set -e  # exit if a command fails
+set -u  # error/exit if variables are unset
+set -f  # disable globbing
+set -o pipefail  # if a command in a pipeline fails, the whole pipeline fails
+
+SCENARIO_TABLE_LOGICAL_ID="DLTTestRunnerStorageDLTScenariosTableAB6F5C2A"
+SCENARIO_BUCKET_LOGICAL_ID="DLTTestRunnerStorageDLTScenariosBucketA9290D21"
+HISTORY_TABLE_LOGICAL_ID="DLTTestRunnerStorageDLTHistoryTable46D850CC"
+SERVICES_FUNCTION_LOGICAL_ID="DLTApiDLTAPIServicesLambda9D76BA5C"
+
+stack_name=$1
+# todo: output instead of resource?
+scenario_table=$(aws cloudformation describe-stack-resource \
+  --stack-name "$stack_name" --logical-resource-id "$SCENARIO_TABLE_LOGICAL_ID" \
+  --query "StackResourceDetail.PhysicalResourceId" --output text)
+scenario_bucket=$(aws cloudformation describe-stack-resource \
+  --stack-name "$stack_name" --logical-resource-id "$SCENARIO_BUCKET_LOGICAL_ID" \
+  --query "StackResourceDetail.PhysicalResourceId" --output text)
+history_table=$(aws cloudformation describe-stack-resource \
+  --stack-name "$stack_name" --logical-resource-id "$HISTORY_TABLE_LOGICAL_ID" \
+  --query "StackResourceDetail.PhysicalResourceId" --output text)
+services_function_name=$(aws cloudformation describe-stack-resource \
+  --stack-name "$stack_name" --logical-resource-id "${SERVICES_FUNCTION_LOGICAL_ID}" \
+  --query "StackResourceDetail.PhysicalResourceId" --output text)
+services_function_arn=$(aws lambda get-function --function-name "$services_function_name" \
+  --query "Configuration.FunctionArn" --output text)
+
+# the cli should paginate this call, but this isn't tested.
+test_ids=$(aws dynamodb scan \
+  --table-name $scenario_table --projection-expression testId \
+  --query "Items[].testId.S" --output text)
+
+# we assume the format is always public/test-scenarios/${testType}/${id}.${ext}
+script_assets=$(aws s3api list-objects-v2 \
+  --bucket "$scenario_bucket" --prefix "public/test-scenarios/" \
+  --query "Contents[].Key" --output text)
+for asset in $script_assets; do
+  test_id=$(echo "$asset" | cut -d'/' -f4 | cut -d'.' -f1)
+  if [[ ! "$test_ids" =~ $test_id ]]; then
+   echo "s3://$scenario_bucket/$asset"
+  fi
+done
+
+# we assume the format is always test-scenarios/${id}-${region}.json
+json_assets=$(aws s3api list-objects-v2 \
+  --bucket "$scenario_bucket" --prefix "test-scenarios/" \
+  --query "Contents[].Key" --output text)
+for asset in $json_assets; do
+  test_id=$(echo "$asset" | cut -d'/' -f2 | cut -d'-' -f1)
+  if [[ ! "$test_ids" =~ $test_id ]]; then
+   echo "s3://$scenario_bucket/$asset"
+  fi
+done
+
+# we assume the format is always results/${id}/*
+result_assets=$(aws s3api list-objects-v2 \
+  --bucket "$scenario_bucket" --prefix "results/" \
+  --query "Contents[].Key" --output text)
+for asset in $result_assets; do
+  test_id=$(echo "$asset" | cut -d'/' -f2)
+  if [[ ! "$test_ids" =~ $test_id ]]; then
+   echo "s3://$scenario_bucket/$asset"
+  fi
+done
+
+# History Table should not have orphaned resources, but we check anyway
+# for the next history query we return two values (tab seperated), so we only split on new lines
+SAVEIFS=$IFS;IFS=$'\n'
+history_assets=$(aws dynamodb scan \
+  --table-name "$history_table" --projection-expression testId,testRunId \
+  --query "Items[].[testId.S,testRunId.S]" --output text)
+for asset in $history_assets; do
+  test_id=$(echo "$asset" | cut -f1)
+  test_run_id=$(echo "$asset" | cut -f2)
+  if [[ ! "$test_ids" =~ $test_id ]]; then
+    echo "dynamodb://$history_table/$test_id/$test_run_id"
+  fi
+done
+IFS=$SAVEIFS
+
+# There should be no eventbridge rules left over, but we check anyway
+rules=$(aws events list-rule-names-by-target --target-arn "$services_function_arn" \
+  --query "RuleNames" --output text)
+for rule in $rules; do
+  # `${rule//Scheduled/}` removes the word Scheduled from the rule variable
+  if [[ ! "$test_ids" =~ ${rule//Scheduled/} ]]; then
+    echo "events://rules/${rule}"
+  fi
+done

--- a/source/api-services/lib/scenarios/index.spec.js
+++ b/source/api-services/lib/scenarios/index.spec.js
@@ -16,6 +16,7 @@ const mockAWS = require("aws-sdk");
 
 mockAWS.S3 = jest.fn(() => ({
   putObject: mockS3,
+  deleteObject: mockS3,
 }));
 mockAWS.StepFunctions = jest.fn(() => ({
   startExecution: mockStepFunctions,
@@ -76,6 +77,7 @@ let getData = {
     name: "mytest",
     status: "running",
     testScenario: '{"name":"example"}',
+    testType: "simple",
     testTaskConfigs: [
       {
         region: "us-east-1",
@@ -93,6 +95,7 @@ let getDataWithConfigs = {
     name: "mytest",
     status: "running",
     testScenario: '{"name":"example"}',
+    testType: "simple",
     testTaskConfigs: [
       {
         region: "us-east-1",
@@ -129,6 +132,7 @@ let getDataWithNoConfigs = {
     name: "mytest",
     status: "running",
     testScenario: '{"name":"example"}',
+    testType: "simple",
   },
 };
 
@@ -138,6 +142,7 @@ let getDataWithEmptyConfigs = {
     name: "mytest",
     status: "running",
     testScenario: '{"name":"example"}',
+    testType: "simple",
     testTaskConfigs: [{}],
   },
 };
@@ -1644,11 +1649,21 @@ describe("#SCENARIOS API:: ", () => {
         return Promise.resolve();
       },
     }));
+    mockS3.mockImplementationOnce(() => ({
+      promise() {
+        // deleteObject
+        return Promise.resolve();
+      },
+    }));
 
     const response = await lambda.deleteTest(testId, context.functionName);
     const expectedDeleteDashboardParams = [`EcsLoadTesting-${testId}-${getRegionalConf.Item.region}`];
     expect(response).toEqual("success");
     expect(mockCloudWatch).toHaveBeenCalledWith({ DashboardNames: expectedDeleteDashboardParams });
+    expect(mockS3).toHaveBeenCalledWith({
+      Bucket: "bucket",
+      Key: `test-scenarios/${testId}-${getRegionalConf.Item.region}.json`,
+    });
   });
 
   it('should return "SUCCESS" when "DELETETEST" has unprocessed entries from "deleteTestHistory', async () => {
@@ -1713,11 +1728,21 @@ describe("#SCENARIOS API:: ", () => {
         return Promise.resolve();
       },
     }));
+    mockS3.mockImplementationOnce(() => ({
+      promise() {
+        // deleteObject
+        return Promise.resolve();
+      },
+    }));
 
     const response = await lambda.deleteTest(testId, context.functionName);
     const expectedDeleteDashboardParams = [`EcsLoadTesting-${testId}-${getRegionalConf.Item.region}`];
     expect(response).toEqual("success");
     expect(mockCloudWatch).toHaveBeenCalledWith({ DashboardNames: expectedDeleteDashboardParams });
+    expect(mockS3).toHaveBeenCalledWith({
+      Bucket: "bucket",
+      Key: `test-scenarios/${testId}-${getRegionalConf.Item.region}.json`,
+    });
   });
 
   it('DELETE should return "SUCCESS" when no metrics are found', async () => {
@@ -1776,6 +1801,12 @@ describe("#SCENARIOS API:: ", () => {
     }));
     mockLambda.mockImplementationOnce(() => ({
       promise() {
+        return Promise.resolve();
+      },
+    }));
+    mockS3.mockImplementationOnce(() => ({
+      promise() {
+        // deleteObject
         return Promise.resolve();
       },
     }));

--- a/source/infrastructure/lib/back-end/scenarios-storage.ts
+++ b/source/infrastructure/lib/back-end/scenarios-storage.ts
@@ -68,7 +68,7 @@ export class ScenarioTestRunnerStorageConstruct extends Construct {
       statements: [
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: ["s3:HeadObject", "s3:PutObject", "s3:GetObject", "s3:ListBucket"],
+          actions: ["s3:HeadObject", "s3:PutObject", "s3:GetObject", "s3:DeleteObject", "s3:ListBucket"],
           resources: [this.scenariosBucket.bucketArn, `${this.scenariosBucket.bucketArn}/*`],
         }),
       ],

--- a/source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts
+++ b/source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts
@@ -10,6 +10,7 @@ import {
   CfnParameter,
   CfnResource,
   CfnRule,
+  Duration,
   Fn,
   IAspect,
   Stack,
@@ -29,6 +30,7 @@ import { TaskRunnerStepFunctionConstruct } from "./back-end/step-functions";
 import { TestRunnerLambdasConstruct } from "./back-end/test-task-lambdas";
 import { FargateVpcConstruct } from "./testing-resources/vpc";
 import { RealTimeDataConstruct } from "./testing-resources/real-time-data";
+import { LifecycleRule } from "aws-cdk-lib/aws-s3";
 
 /**
  * CDK Aspect implementation to set up conditions to the entire Construct resources
@@ -167,6 +169,21 @@ export class DLTStack extends Stack {
       constraintDescription: "The Egress CIDR block must be a valid IP CIDR range of the form x.x.x.x/x.",
     });
 
+    // S3 LifecycleRules
+    // creating a lifecycleRule conditionally on a CfnParameter is hard in CDK, so we use a high number by default
+    const removeNonCurrentVersionsAfter = new CfnParameter(this, "RemoveNonCurrentVersionsAfter", {
+      type: "Number",
+      description: "Number of days to keep non current versions.",
+      default: 12 * 31,
+      minValue: 1,
+    });
+    const removeResultsAfter = new CfnParameter(this, "RemoveResultsAfter", {
+      type: "Number",
+      description: "Number of days to keep results.",
+      default: 10 * 12 * 31,
+      minValue: 1,
+    });
+
     // CloudFormation metadata
     this.templateOptions.metadata = {
       "AWS::CloudFormation::Interface": {
@@ -188,6 +205,10 @@ export class DLTStack extends Stack {
               egressCidrBlock.logicalId,
             ],
           },
+          {
+            Label: { default: "S3 Lifecycle Rules" },
+            Parameters: [removeNonCurrentVersionsAfter.logicalId, removeResultsAfter.logicalId],
+          },
         ],
         ParameterLabels: {
           [adminName.logicalId]: { default: "* Console Administrator Name" },
@@ -199,6 +220,8 @@ export class DLTStack extends Stack {
           [subnetACidrBlock.logicalId]: { default: "AWS Fargate Subnet A CIDR Block" },
           [subnetBCidrBlock.logicalId]: { default: "AWS Fargate Subnet A CIDR Block" },
           [egressCidrBlock.logicalId]: { default: "AWS Fargate SecurityGroup CIDR Block" },
+          [removeNonCurrentVersionsAfter.logicalId]: { default: "The days after which to remove Non-current Versions" },
+          [removeResultsAfter.logicalId]: { default: "The days after which to remove result files" },
         },
       },
     };
@@ -303,10 +326,22 @@ export class DLTStack extends Stack {
       solutionId,
     });
 
+    const nonCurrentRemovalLifecycleRule: LifecycleRule = {
+      enabled: true,
+      // todo: parameter and condition
+      noncurrentVersionExpiration: Duration.days(removeNonCurrentVersionsAfter.valueAsNumber), // remove old versions (we delete objects when tests are deleted)
+    };
+    const resultsRemovalLifecycleRule: LifecycleRule = {
+      enabled: true,
+      prefix: "results/",
+      expiration: Duration.days(removeResultsAfter.valueAsNumber), // todo: parameter and condition
+    };
+
     const dltStorage = new ScenarioTestRunnerStorageConstruct(this, "DLTTestRunnerStorage", {
       s3LogsBucket,
       cloudFrontDomainName: dltConsole.cloudFrontDomainName,
       solutionId,
+      lifecycleRules: [nonCurrentRemovalLifecycleRule, resultsRemovalLifecycleRule],
     });
 
     const customResourceInfra = new CustomResourceInfraConstruct(this, "DLTCustomResourceInfra", {

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
@@ -2405,6 +2405,18 @@ exports[`Distributed Load Testing stack test 1`] = `
           ],
           "Version": "2012-10-17",
         },
+        "Tags": [
+          {
+            "Key": "SolutionId",
+            "Value": {
+              "Fn::FindInMap": [
+                "Solution",
+                "Config",
+                "SolutionId",
+              ],
+            },
+          },
+        ],
       },
       "Type": "AWS::IoT::Policy",
     },

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
@@ -5510,6 +5510,7 @@ exports[`Distributed Load Testing stack test 1`] = `
                 "s3:HeadObject",
                 "s3:PutObject",
                 "s3:GetObject",
+                "s3:DeleteObject",
                 "s3:ListBucket",
               ],
               "Effect": "Allow",

--- a/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/distributed-load-testing-on-aws-stack.test.ts.snap
@@ -191,6 +191,15 @@ exports[`Distributed Load Testing stack test 1`] = `
             "EgressCidr",
           ],
         },
+        {
+          "Label": {
+            "default": "S3 Lifecycle Rules",
+          },
+          "Parameters": [
+            "RemoveNonCurrentVersionsAfter",
+            "RemoveResultsAfter",
+          ],
+        },
       ],
       "ParameterLabels": {
         "AdminEmail": {
@@ -210,6 +219,12 @@ exports[`Distributed Load Testing stack test 1`] = `
         },
         "ExistingVPCId": {
           "default": "The ID of an existing VPC in this region. Ex: \`vpc-1a2b3c4d5e6f\`",
+        },
+        "RemoveNonCurrentVersionsAfter": {
+          "default": "The days after which to remove Non-current Versions",
+        },
+        "RemoveResultsAfter": {
+          "default": "The days after which to remove result files",
         },
         "SubnetACidrBlock": {
           "default": "AWS Fargate Subnet A CIDR Block",
@@ -334,6 +349,18 @@ exports[`Distributed Load Testing stack test 1`] = `
       "AllowedPattern": "(?:^$|^vpc-[a-zA-Z0-9-]+)",
       "Description": "Existing VPC ID",
       "Type": "String",
+    },
+    "RemoveNonCurrentVersionsAfter": {
+      "Default": 372,
+      "Description": "Number of days to keep non current versions.",
+      "MinValue": 1,
+      "Type": "Number",
+    },
+    "RemoveResultsAfter": {
+      "Default": 3720,
+      "Description": "Number of days to keep results.",
+      "MinValue": 1,
+      "Type": "Number",
     },
     "SubnetACidrBlock": {
       "AllowedPattern": "(?:^$|(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2}))",
@@ -5274,6 +5301,32 @@ exports[`Distributed Load Testing stack test 1`] = `
               "ExposedHeaders": [
                 "ETag",
               ],
+            },
+          ],
+        },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "NoncurrentVersionExpiration": {
+                "NoncurrentDays": {
+                  "Ref": "RemoveNonCurrentVersionsAfter",
+                },
+              },
+              "Status": "Enabled",
+            },
+            {
+              "ExpirationInDays": {
+                "Ref": "RemoveResultsAfter",
+              },
+              "Prefix": "results/",
+              "Status": "Enabled",
+            },
+            {
+              "AbortIncompleteMultipartUpload": {
+                "DaysAfterInitiation": 7,
+              },
+              "ExpiredObjectDeleteMarker": true,
+              "Status": "Enabled",
             },
           ],
         },

--- a/source/infrastructure/test/__snapshots__/scenarios-storage.test.ts.snap
+++ b/source/infrastructure/test/__snapshots__/scenarios-storage.test.ts.snap
@@ -69,6 +69,17 @@ exports[`DLT API Test 1`] = `
             },
           ],
         },
+        "LifecycleConfiguration": {
+          "Rules": [
+            {
+              "AbortIncompleteMultipartUpload": {
+                "DaysAfterInitiation": 7,
+              },
+              "ExpiredObjectDeleteMarker": true,
+              "Status": "Enabled",
+            },
+          ],
+        },
         "LoggingConfiguration": {
           "DestinationBucketName": {
             "Ref": "testLogsBucket85E419AD",


### PR DESCRIPTION
**Description of changes:**
This change will:
- cleanup files from the storage bucket when scenario's are deleted
- delete result files after a configurable amount of days (default: 10 years)
- delete non-current versions in s3 after a configurable amount of days (default: 1 year)

This seemed to use as a good compromise between things that are easy to delete (the test scripts) and things that would need an s3 list-objects (results, where we use a lifecycle instead)

I also included a script to look for resources for test that were already deleted

**Checklist**
- [] :wave: I have run the unit tests, and all unit tests have passed.
- [X] :warning: This pull request might incur a breaking change.

Unit tests: They passed when run on our fork, but currently fail. Unit tests on the main branch also fail for me, so it seems unrelated to this change. I can rebase this branch after the main branch is fixed.


Breaking change: Debatable, it is a change in behaviour, but I don't think anyone would be relying on files sticking around for that long


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
