### PR TITLE
[K6 support] Add support to K6 to create tests

### DIFF
--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/Dockerfile
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/Dockerfile
@@ -1,8 +1,8 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 
-RUN dnf update -y && \
-    curl -sL --retry 3 "https://dl.k6.io/rpm/repo.rpm" -o /tmp/repo.rpm && \
+RUN curl -sL --retry 3 "https://dl.k6.io/rpm/repo.rpm" -o /tmp/repo.rpm && \
     rpm -i /tmp/repo.rpm && rm -f /tmp/repo.rpm && \
+    dnf update -y && \
     dnf install -y python3.11 python3.11-pip java-21-amazon-corretto bc procps jq findutils unzip k6 && \
     dnf clean all
 

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/Dockerfile
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/Dockerfile
@@ -1,7 +1,9 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2023-minimal
 
 RUN dnf update -y && \
-    dnf install -y python3.11 python3.11-pip java-21-amazon-corretto bc procps jq findutils unzip && \
+    curl -sL --retry 3 "https://dl.k6.io/rpm/repo.rpm" -o /tmp/repo.rpm && \
+    rpm -i /tmp/repo.rpm && rm -f /tmp/repo.rpm && \
+    dnf install -y python3.11 python3.11-pip java-21-amazon-corretto bc procps jq findutils unzip k6 && \
     dnf clean all
 
 ENV PIP_INSTALL="pip3.11 install --no-cache-dir"

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
@@ -53,8 +53,9 @@ if [ "$TEST_TYPE" != "simple" ]; then
   fi
 
   if [ "$TEST_TYPE" == "k6" ]; then
-    EXT="js"
+    EXT="ts"
     TYPE_NAME="K6"
+    KPI_EXT="csv"
   fi
 
   if [ "$FILE_TYPE" != "zip" ]; then

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh
@@ -50,7 +50,11 @@ if [ "$TEST_TYPE" != "simple" ]; then
     JMETER_LIB_PATH=`find ~/.bzt/jmeter-taurus -type d -name "lib"`
     echo "cp $PWD/*.jar $JMETER_LIB_PATH"
     cp $PWD/*.jar $JMETER_LIB_PATH 
+  fi
 
+  if [ "$TEST_TYPE" == "k6" ]; then
+    EXT="js"
+    TYPE_NAME="K6"
   fi
 
   if [ "$FILE_TYPE" != "zip" ]; then
@@ -70,21 +74,23 @@ if [ "$TEST_TYPE" != "simple" ]; then
 
     sed -i -e "s|$TEST_ID.$EXT|$TEST_SCRIPT|g" test.json
 
-    # copy bundled plugin jars to jmeter extension folder to make them available to jmeter
-    BUNDLED_PLUGIN_DIR=`find $PWD -type d -name "plugins" | head -n 1`
-    # attempt to copy only if a /plugins folder is present in upload
-    if [ -z "$BUNDLED_PLUGIN_DIR" ]; then
-      echo "skipping plugin installation (no /plugins folder in upload)"
-    else
-      # ensure the jmeter extensions folder exists
-      JMETER_EXT_PATH=`find ~/.bzt/jmeter-taurus -type d -name "ext"`
-      if [ -z "$JMETER_EXT_PATH" ]; then
-        # fail fast - if plugins bundled they will be needed for the tests
-        echo "jmeter extension path (~/.bzt/jmeter-taurus/**/ext) not found - cannot install bundled plugins"
-        exit 1
+    if [ "$TEST_TYPE" == "jmeter" ]; then
+      # copy bundled plugin jars to jmeter extension folder to make them available to jmeter
+      BUNDLED_PLUGIN_DIR=`find $PWD -type d -name "plugins" | head -n 1`
+      # attempt to copy only if a /plugins folder is present in upload
+      if [ -z "$BUNDLED_PLUGIN_DIR" ]; then
+        echo "skipping plugin installation (no /plugins folder in upload)"
+      else
+        # ensure the jmeter extensions folder exists
+        JMETER_EXT_PATH=`find ~/.bzt/jmeter-taurus -type d -name "ext"`
+        if [ -z "$JMETER_EXT_PATH" ]; then
+          # fail fast - if plugins bundled they will be needed for the tests
+          echo "jmeter extension path (~/.bzt/jmeter-taurus/**/ext) not found - cannot install bundled plugins"
+          exit 1
+        fi
+        cp -v $BUNDLED_PLUGIN_DIR/*.jar $JMETER_EXT_PATH
       fi
-      cp -v $BUNDLED_PLUGIN_DIR/*.jar $JMETER_EXT_PATH
-    fi
+    fi    
   fi
 fi
 

--- a/source/console/src/Components/Create/Create.js
+++ b/source/console/src/Components/Create/Create.js
@@ -41,7 +41,7 @@ import RefreshButtons from "../Shared/Buttons/RefreshButtons";
 const FILE_SIZE_LIMIT = 50 * 1024 * 1024;
 
 // Allowed file extensions
-const SCRIPT_FILE_EXTENSIONS = { jmeter: "jmx" };
+const SCRIPT_FILE_EXTENSIONS = { jmeter: "jmx", k6: "js" };
 
 class Create extends React.Component {
   constructor(props) {
@@ -548,7 +548,7 @@ class Create extends React.Component {
   };
 
   uploadFileDescription = () => {
-    if (!["jmeter"].includes(this.state.formValues.testType)) {
+    if (["simple"].includes(this.state.formValues.testType)) {
       return null;
     }
     const ext = SCRIPT_FILE_EXTENSIONS[this.state.formValues.testType];
@@ -1367,6 +1367,7 @@ class Create extends React.Component {
                 >
                   <option value="simple">Single HTTP Endpoint</option>
                   <option value="jmeter">JMeter</option>
+                  <option value="k6">K6</option>
                 </Input>
               </FormGroup>
               {this.state.formValues.testType === "simple" && (

--- a/source/console/src/Components/Create/Create.js
+++ b/source/console/src/Components/Create/Create.js
@@ -41,7 +41,7 @@ import RefreshButtons from "../Shared/Buttons/RefreshButtons";
 const FILE_SIZE_LIMIT = 50 * 1024 * 1024;
 
 // Allowed file extensions
-const SCRIPT_FILE_EXTENSIONS = { jmeter: "jmx", k6: "js" };
+const SCRIPT_FILE_EXTENSIONS = { jmeter: "jmx", k6: "ts" };
 
 class Create extends React.Component {
   constructor(props) {


### PR DESCRIPTION
This PR adds a support to use [Grafana K6](https://grafana.com/docs/k6/latest/) scripts to run tests, adding an extra tool to run the stress tests. 

This PR includes:
* changes in the UI to define the K6 tests
* installation of the K6 tooling in the image

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
