### PR TITLE
Show the start time instead of the end time in the results history

### DIFF
--- a/source/console/src/Components/History/History.js
+++ b/source/console/src/Components/History/History.js
@@ -57,7 +57,7 @@ class History extends React.Component {
           <Table borderless responsive>
             <thead>
               <tr>
-                <th>Run Time</th>
+                <th>Started at</th>
                 <th>Total Task Count</th>
                 <th>Total Concurrency</th>
                 <th>Average Response Time</th>
@@ -78,7 +78,7 @@ class History extends React.Component {
                     key={i.testRunId}
                     className={this.state.rowIsActive === index ? "rowActive" : ""}
                   >
-                    <td id={`endTime-${index}`}>{i.endTime}</td>
+                    <td id={`startTime-${index}`}>{i.startTime}</td>
                     <td id={`taskCount-${index}`}>{loadInfo.taskCount}</td>
                     <td id={`concurrency-${index}`}>{loadInfo.concurrency}</td>
                     <td id={`avgResponseTime-${index}`}>{i.results.total?.avg_rt}s</td>
@@ -101,7 +101,7 @@ class History extends React.Component {
                             this.setState({ rowIsActive: -1 });
                           }}
                         >
-                          <h2>Test run from {i.endTime}</h2>
+                          <h2>Test run from {testRun.startTime} to {testRun.endTime}</h2>
                         </ModalHeader>
                         <ModalBody>
                           <DetailsTable

--- a/source/console/src/Components/History/History.js
+++ b/source/console/src/Components/History/History.js
@@ -53,10 +53,13 @@ class History extends React.Component {
 
     // Enrich the history with more data, and sort by start time.
     const resultsHistory = history.map((testRun) => {
-      const loadInfo = testRun.testTaskConfigs.reduce((previous, current) => ({
-        taskCount: previous.taskCount + current.taskCount,
-        concurrency: previous.concurrency + current.concurrency,
-      }), { taskCount: 0, concurrency: 0 });
+      const loadInfo = testRun.testTaskConfigs.reduce(
+        (previous, current) => ({
+          taskCount: previous.taskCount + current.taskCount,
+          concurrency: previous.concurrency + current.concurrency,
+        }),
+        { taskCount: 0, concurrency: 0 }
+      );
       const data = this.getHistoricalTest(testRun);
       return {
         testRun,
@@ -81,7 +84,7 @@ class History extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {resultsHistory.map(({testRun, data, loadInfo}, index) => {
+              {resultsHistory.map(({ testRun, data, loadInfo }, index) => {
                 return (
                   <tr
                     id={`historyRow-${index}`}
@@ -111,7 +114,9 @@ class History extends React.Component {
                             this.setState({ rowIsActive: -1 });
                           }}
                         >
-                          <h2>Test run from {testRun.startTime} to {testRun.endTime}</h2>
+                          <h2>
+                            Test run from {testRun.startTime} to {testRun.endTime}
+                          </h2>
                         </ModalHeader>
                         <ModalBody>
                           <DetailsTable

--- a/source/console/src/Components/History/History.js
+++ b/source/console/src/Components/History/History.js
@@ -56,7 +56,7 @@ class History extends React.Component {
       const loadInfo = testRun.testTaskConfigs.reduce((previous, current) => ({
         taskCount: previous.taskCount + current.taskCount,
         concurrency: previous.concurrency + current.concurrency,
-      }));
+      }), { taskCount: 0, concurrency: 0 });
       const data = this.getHistoricalTest(testRun);
       return {
         testRun,

--- a/source/console/src/Components/History/History.js
+++ b/source/console/src/Components/History/History.js
@@ -50,6 +50,21 @@ class History extends React.Component {
 
   render() {
     const history = this.props.data.history || [];
+
+    // Enrich the history with more data, and sort by start time.
+    const resultsHistory = history.map((testRun) => {
+      const loadInfo = testRun.testTaskConfigs.reduce((previous, current) => ({
+        taskCount: previous.taskCount + current.taskCount,
+        concurrency: previous.concurrency + current.concurrency,
+      }));
+      const data = this.getHistoricalTest(testRun);
+      return {
+        testRun,
+        data,
+        loadInfo,
+      };
+    });
+    resultsHistory.sort((a, b) => new Date(b.testRun.startTime) - new Date(a.testRun.startTime));
     return (
       <div>
         <div className="box">
@@ -66,23 +81,18 @@ class History extends React.Component {
               </tr>
             </thead>
             <tbody>
-              {history.map((i, index) => {
-                const loadInfo = i.testTaskConfigs.reduce((previous, current) => ({
-                  taskCount: previous.taskCount + current.taskCount,
-                  concurrency: previous.concurrency + current.concurrency,
-                }));
-                const data = this.getHistoricalTest(i);
+              {resultsHistory.map(({testRun, data, loadInfo}, index) => {
                 return (
                   <tr
                     id={`historyRow-${index}`}
-                    key={i.testRunId}
+                    key={testRun.testRunId}
                     className={this.state.rowIsActive === index ? "rowActive" : ""}
                   >
-                    <td id={`startTime-${index}`}>{i.startTime}</td>
+                    <td id={`startTime-${index}`}>{testRun.startTime}</td>
                     <td id={`taskCount-${index}`}>{loadInfo.taskCount}</td>
                     <td id={`concurrency-${index}`}>{loadInfo.concurrency}</td>
-                    <td id={`avgResponseTime-${index}`}>{i.results.total?.avg_rt}s</td>
-                    <td id={`successPercent-${index}`}>{i.succPercent}%</td>
+                    <td id={`avgResponseTime-${index}`}>{testRun.results.total?.avg_rt}s</td>
+                    <td id={`successPercent-${index}`}>{testRun.succPercent}%</td>
                     <td id={`detailsLink-${index}`}>
                       <div className="text-link history-link" onClick={() => this.onClick(index)}>
                         View details


### PR DESCRIPTION
**Description of changes:**

This PR improves the results display:
1. Show the start time instead of the end time in the table
2. Sort the results by the start time so that one can easily find a particular run back

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [x] :warning: This pull request might incur a breaking change: Showing the start instead of the end time.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
