### PR TITLE
Add toggle to run test without downloading embedded resources

### DIFF
--- a/source/console/src/Components/Create/Create.js
+++ b/source/console/src/Components/Create/Create.js
@@ -228,6 +228,7 @@ class Create extends React.Component {
       endpoint,
       method,
       onSchedule,
+      retrieveEmbeddedResources,
     } = this.state.formValues;
 
     if (!this.form.current.reportValidity()) {
@@ -261,7 +262,17 @@ class Create extends React.Component {
     console.log("Payload", payload);
     if (!!parseInt(onSchedule)) payload = this.onSchedulePayloadUpdate(payload);
 
-    await this.setPayloadTestScenario({ testType, testName, endpoint, method, headers, body, payload, testId });
+    await this.setPayloadTestScenario({
+        testType,
+        testName,
+        endpoint,
+        method,
+        headers,
+        body,
+        payload,
+        retrieveEmbeddedResources,
+        testId,
+      });
 
     this.alertsForBadCronInputs();
     this.setState({ isLoading: true });
@@ -284,7 +295,7 @@ class Create extends React.Component {
   };
 
   async setPayloadTestScenario(props) {
-    let { testType, testName, endpoint, method, headers, body, payload, testId } = props;
+    let { testType, testName, endpoint, method, headers, body, payload, retrieveEmbeddedResources, testId } = props;
     if (testType === "simple") {
       headers = headers || "{}";
       body = body || "{}";
@@ -297,6 +308,7 @@ class Create extends React.Component {
       }
 
       payload.testScenario.scenarios[testName] = {
+        "retrieve-resources": retrieveEmbeddedResources ?? true,
         requests: [
           {
             url: endpoint,
@@ -361,7 +373,9 @@ class Create extends React.Component {
   handleInputChange(event) {
     this.setState({ submitFailure: false });
 
-    const value = event.target.name === "showLive" ? event.target.checked : event.target.value;
+    const value = ["showLive", "retrieveEmbeddedResources"].includes(event.target.name)
+      ? event.target.checked
+      : event.target.value;
     const name = event.target.name;
     const id = event.target.id;
 
@@ -1331,13 +1345,6 @@ class Create extends React.Component {
               </Collapse>
               {this.state.activeTab === "3" && this.schedulingErrors()}
               <FormGroup check>
-                <Input
-                  name="showLive"
-                  id="showLive"
-                  type="checkbox"
-                  checked={this.state.formValues.showLive}
-                  onChange={this.handleInputChange}
-                />
                 <Label check>
                   <Input
                     name="showLive"
@@ -1384,6 +1391,16 @@ class Create extends React.Component {
                     <FormText color="muted">
                       Target URL to run tests against, supports http and https. i.e. https://example.com:8080.
                     </FormText>
+                    <div className="mt-2">
+                      <Input
+                        name="retrieveEmbeddedResources"
+                        id="retrieveEmbeddedResources"
+                        type="checkbox"
+                        onChange={this.handleInputChange}
+                        defaultChecked={true}
+                      />{" "}
+                      <Label for="retrieveEmbeddedResources">Retrieve embedded resources</Label>
+                    </div>
                   </FormGroup>
                   <FormGroup>
                     <Label for="method">HTTP Method</Label>

--- a/source/console/src/Components/Create/Create.spec.js
+++ b/source/console/src/Components/Create/Create.spec.js
@@ -101,6 +101,7 @@ describe("Functions Testing", () => {
       testScenario: {
         scenarios: {
           testName: {
+            "retrieve-resources": true,
             requests: [
               {
                 url: "endpoint",

--- a/source/console/src/Components/Details/DetailsTable.js
+++ b/source/console/src/Components/Details/DetailsTable.js
@@ -64,6 +64,11 @@ class DetailsTable extends React.Component {
                   </Col>
                   <Col id="testEndpoint" sm="9">
                     {data.endpoint}
+                    <div className="mt-1">
+                      {Object.values(data.testScenario.scenarios)[0]["retrieve-resources"] === false
+                        ? "Without retrieving embedded resources"
+                        : "Including embedded resources"}
+                    </div>
                   </Col>
                 </Row>
                 <Row className="detail">


### PR DESCRIPTION
Currently, by default all tests ran will download all resources embedded in the page. For most cases this is probably a sensible default. However in our case (and this probably isn't really an edge case either) we're serving HTML from our own servers, and serving assets from a CDN.

We want to be able to load test our own service, without accessing the CDN, because:

- It's more representative of the metric we're actually interested in (our servers' performance, not the end-users' total load time).
- We avoid getting rate limited by the CDN, skewing our results.

**Description of changes:**
This change proposes adding a checkbox labeled "Retrieve embedded resources" under the "Endpoint" field in the "Simple" test type. By default it's checked, so if a user doesn't touch it, the behaviour doesn't change from the current state. 

<img width="569" alt="Screenshot 2025-06-27 at 13 59 29" src="https://github.com/user-attachments/assets/ffedb66b-d2ce-4c91-816b-d22528d04451" />

The value of the checkbox is passed to the `retrieve-resources` property in the generated test definition. See https://gettaurus.org/docs/JMeter/#Global-Settings.

I have not added the checkbox to the form for creating a test from a JMeter test definition file, since it's impossible to tell what's in there and if/how the flag would affect it.

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
