### PR TITLE
Fix VPC parameter validation and security group reference for existing VPC deployment

### DIFF
--- a/source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts
+++ b/source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts
@@ -124,7 +124,7 @@ export class DLTStack extends Stack {
       description: "You may leave the parameter blank if you are using existing VPC",
       allowedPattern: "(^$|(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2}))",
       constraintDescription: "The VPC CIDR block must be a valid IP CIDR range of the form x.x.x.x/x.",
-      minLength: 9,
+      minLength: 0,
       maxLength: 18,
     });
 


### PR DESCRIPTION
**Issue #, if available:**
N/A

**Description of changes:**
This PR fixes VPC deployment issues when using existing VPC infrastructure by addressing parameter validation and security group VPC reference problems.

**Changes Made:**
- **VPC Parameter Validation Fix**: Changed `VpcCidrBlock` parameter `minLength` from 9 to 0 in `distributed-load-testing-on-aws-stack.ts` to allow empty input when using existing VPC
- **Security Group VPC Reference Fix**: Added conditional VPC reference for ECS security group using CloudFormation `Fn::If` in `ecs.ts` to properly handle both new and existing VPC scenarios

**Problem Solved:**
- Resolves deployment failures when using existing VPC due to parameter validation requiring non-empty CIDR block
- Fixes security group VPC reference issues in existing VPC deployment scenarios
- Ensures proper conditional logic for both new VPC creation and existing VPC usage

**Files Modified:**
- `source/infrastructure/lib/distributed-load-testing-on-aws-stack.ts` - VPC parameter validation fix (1 line changed)
- `source/infrastructure/lib/testing-resources/ecs.ts` - Security group VPC reference fix (9 lines added)

**Checklist**
- [x] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.
