### PR TITLE
Fix #268: Avoid JMeter HTTP2 plugin dependencies' vulnerabilities

### DIFF
--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/.bzt-rc
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/.bzt-rc
@@ -21,7 +21,6 @@ modules:
     - jpgc-prmctl
     - jpgc-tst
     - jpgc-udp
-    - bzm-http2
     - bzm-random-csv
     plugins-manager:
       download-link: https://search.maven.org/remotecontent?filepath=kg/apc/jmeter-plugins-manager/{version}/jmeter-plugins-manager-{version}.jar

--- a/deployment/ecr/distributed-load-testing-on-aws-load-tester/jar_updater.py
+++ b/deployment/ecr/distributed-load-testing-on-aws-load-tester/jar_updater.py
@@ -19,9 +19,6 @@ Affected Jmeter jars:
     * json-path v2.7.0 will be replaced with v2.9.0
     * dnsjava v2.1.9 will be replaced with v3.6.1
     * xstream will be replaced with v1.4.21
-    * http2-hpack will be replaced with v11.0.26
-    * jetty-http will be replaced with v12.0.25
-    * http2-common will be replaced with v11.0.26
     * kotlin-stdlib will be replaced with v2.1.0
     * commons-lang3 will be replaced with v3.18.0
     * rhino v1.7.14 will be replaced with v1.7.14.1 (fixes CVE-2025-66453)
@@ -68,9 +65,6 @@ JMETER_COMPONENTS: Dict[str, str] = {
     "json-path": "com/jayway/jsonpath/json-path/2.9.0/json-path-2.9.0.jar",
     "dnsjava": "dnsjava/dnsjava/3.6.1/dnsjava-3.6.1.jar",
     "xstream": "com/thoughtworks/xstream/xstream/1.4.21/xstream-1.4.21.jar",
-    "http2-hpack": "org/eclipse/jetty/http2/http2-hpack/11.0.26/http2-hpack-11.0.26.jar",
-    "jetty-http": "org/eclipse/jetty/jetty-http/11.0.26/jetty-http-11.0.26.jar",
-    "http2-common": "org/eclipse/jetty/http2/http2-common/11.0.26/http2-common-11.0.26.jar",
     "kotlin-stdlib": "org/jetbrains/kotlin/kotlin-stdlib/2.1.0/kotlin-stdlib-2.1.0.jar",
     "commons-lang3": "org/apache/commons/commons-lang3/3.18.0/commons-lang3-3.18.0.jar",
     "rhino": "org/mozilla/rhino/1.7.14.1/rhino-1.7.14.1.jar", # NOSONAR


### PR DESCRIPTION
**Issue #, if available:** #268

**Description of changes:**
Remove the JMeter Blazemeter HTTP2 plugin from the list of pre-installed plugins to avoid adding its dependencies with vulnerabilities in the Taurus image.

By relying on Taurus installing any missing plugins just before running a JMeter script the HTTP2 plugin can still be used.

Accordingly remove the unnecessary updates from the `jar_updater.py`.

**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
