### PR TITLE
Feature: Make each runner aware of total number of Tasks

### DIFF
--- a/source/task-runner/index.js
+++ b/source/task-runner/index.js
@@ -309,6 +309,7 @@ exports.handler = async (event, context) => {
             { name: "FILE_TYPE", value: fileType },
             { name: "LIVE_DATA_ENABLED", value: `live=${showLive}` },
             { name: "TIMEOUT", value: timeout.toString() },
+            { name: "TASK_COUNT", value: runTaskCount.toString() },
             { name: "PREFIX", value: event.prefix },
             { name: "SCRIPT", value: "ecslistener.py" },
           ],

--- a/source/task-runner/lib/index.spec.js
+++ b/source/task-runner/lib/index.spec.js
@@ -124,6 +124,7 @@ let mockParam = {
           { name: "FILE_TYPE", value: "none" },
           { name: "LIVE_DATA_ENABLED", value: "live=true" },
           { name: "TIMEOUT", value: calcTimeout(event.testTaskConfig.taskCount) },
+          { name: "TASK_COUNT", value: event.testTaskConfig.taskCount.toString() },
           { name: "PREFIX", value: event.prefix },
           { name: "SCRIPT", value: "ecslistener.py" },
         ],
@@ -269,6 +270,7 @@ describe("#TASK RUNNER:: ", () => {
 
     event.testTaskConfig.taskCount = 20;
     modifyContainerOverrides("TIMEOUT", calcTimeout(event.testTaskConfig.taskCount));
+    modifyContainerOverrides("TASK_COUNT", event.testTaskConfig.taskCount.toString());
     let tasks = getTaskIds(19);
     let expectedResponse = {
       isRunning: true,
@@ -300,7 +302,8 @@ describe("#TASK RUNNER:: ", () => {
     expect(response).toEqual(expect.objectContaining(expectedResponse));
   });
   it("should return when launching leader task is successful", async () => {
-    mockParam.overrides.containerOverrides[0].environment[8].value = "ecscontroller.py";
+    modifyContainerOverrides("SCRIPT", "ecscontroller.py");
+    modifyContainerOverrides("TASK_COUNT", "1");
     mockParam.overrides.containerOverrides[0].environment.push({ name: "IPNETWORK", value: "" });
     let taskIds = getTaskIds(5);
     event.taskIds = taskIds;


### PR DESCRIPTION
**Issue #, if available:** n/a

**Description of changes:**

When distributing load across multiple Tasks it may be desirable to let each runner know how many Tasks there are in total, for example so as to scale the load each individual Task is supposed to generate.

Currently, the only way for a script to find out the total Task count is to find and parse the `test.json` file.

This PR simplifies that by injecting an environment variable `TASK_COUNT` in the container.

**Checklist**
- [X] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
