### PR TITLE
Fix: Incorrect Response Time Live Chart Axis Label

### DIFF
--- a/source/webui/src/pages/scenarios/components/TaskStatus.tsx
+++ b/source/webui/src/pages/scenarios/components/TaskStatus.tsx
@@ -115,7 +115,7 @@ export function TaskStatus({ scenario_definition, isRefreshing }: TaskStatusProp
       // Create chart instance
       avgRtChartInstance.current = createRegionalTimeSeriesChart(ctx, getFlatChartData(), {
         metric: ChartMetric.AverageResponseTime,
-        yAxisTitle: "Response Time (ms)",
+        yAxisTitle: "Response Time (s)",
         regionColors: getRegionColors(),
       });
     }


### PR DESCRIPTION
**Issue #, if available:** none logged

**Description of changes:**
The live response time chart contains measurements in seconds but the axis shows Milliseconds (ms).
This PR fixes that.

**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
