### PR TITLE
Add HEAD method to CORS allowed methods

### DIFF
--- a/source/infrastructure/lib/back-end/scenarios-storage.ts
+++ b/source/infrastructure/lib/back-end/scenarios-storage.ts
@@ -44,7 +44,7 @@ export class ScenarioTestRunnerStorageConstruct extends Construct {
       blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
       cors: [
         {
-          allowedMethods: [HttpMethods.GET, HttpMethods.POST, HttpMethods.PUT],
+          allowedMethods: [HttpMethods.GET, HttpMethods.POST, HttpMethods.PUT, HttpMethods.HEAD],
           allowedOrigins: [props.webAppURL],
           allowedHeaders: ["*"],
           exposedHeaders: ["ETag"],


### PR DESCRIPTION
**Issue #, if available:**
This resolves a CORS issue while running scenarios that require an upload to s3. Without HEAD, my browsers fell back to OPTIONS which resulted in a 403 and a `Network Error` in the DLT console


**Description of changes:**
Added HEAD method to the CORS settings for the scenarios storage bucket.

**Checklist**
- [ ] :wave: I have run the unit tests, and all unit tests have passed.
- [ ] :warning: This pull request might incur a breaking change.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
