### PR TITLE
feat: add OIDC federation support (Entra ID / external IdP)

### DIFF
--- a/source/infrastructure/lambda/aws-exports-handler/index.ts
+++ b/source/infrastructure/lambda/aws-exports-handler/index.ts
@@ -18,6 +18,8 @@ interface CloudFormationEvent {
     UserFilesBucketRegion: string;
     IoTEndpoint: string;
     IoTPolicy: string;
+    OAuthDomain?: string;
+    OAuthRedirectUrl?: string;
   };
   PhysicalResourceId?: string;
 }
@@ -44,11 +46,13 @@ export const handler = async (event: CloudFormationEvent): Promise<CloudFormatio
     UserFilesBucketRegion,
     IoTEndpoint,
     IoTPolicy,
+    OAuthDomain,
+    OAuthRedirectUrl,
   } = ResourceProperties;
 
   try {
     if (RequestType === "Create" || RequestType === "Update") {
-      const awsExports = {
+      const awsExports: Record<string, string> = {
         UserPoolId,
         PoolClientId,
         IdentityPoolId,
@@ -58,6 +62,9 @@ export const handler = async (event: CloudFormationEvent): Promise<CloudFormatio
         IoTEndpoint,
         IoTPolicy,
       };
+
+      if (OAuthDomain) awsExports.OAuthDomain = OAuthDomain;
+      if (OAuthRedirectUrl) awsExports.OAuthRedirectUrl = OAuthRedirectUrl;
 
       await s3Client.send(
         new PutObjectCommand({

--- a/source/webui/src/components/navigation/TopNavigationBar.tsx
+++ b/source/webui/src/components/navigation/TopNavigationBar.tsx
@@ -3,9 +3,23 @@
 
 import { TopNavigation, TopNavigationProps } from "@cloudscape-design/components";
 import { useAuthenticator } from "@aws-amplify/ui-react";
+import { fetchAuthSession } from "aws-amplify/auth";
+import { useState, useEffect } from "react";
 
 export default function TopNavigationBar() {
   const { user, signOut } = useAuthenticator();
+  const [displayName, setDisplayName] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchAuthSession()
+      .then((session) => {
+        const payload = session.tokens?.idToken?.payload;
+        if (payload) {
+          setDisplayName((payload.name as string) || (payload.email as string) || null);
+        }
+      })
+      .catch(() => {});
+  }, [user]);
 
   const solutionIdentity: TopNavigationProps.Identity = {
     href: "/",
@@ -20,7 +34,7 @@ export default function TopNavigationBar() {
   const utilities: TopNavigationProps.Utility[] = [
     {
       type: "menu-dropdown",
-      text: user.username ?? "User",
+      text: displayName ?? user.username ?? "User",
       iconName: "user-profile",
       items: [
         {

--- a/source/webui/src/contexts/UserContext.tsx
+++ b/source/webui/src/contexts/UserContext.tsx
@@ -58,14 +58,19 @@ export const UserContextProvider = (props: { children: ReactNode }) => {
         ...responseUser,
       });
       try {
-        const userAttributesOutput = await fetchUserAttributes();
-        setEmail(userAttributesOutput.email ?? null);
-
-        // Attach IoT policy when user is authenticated
+        // Attach IoT policy first — fetchUserAttributes may fail for federated users
+        // and must not block IoT setup needed for real-time metrics
         const response = await fetch("/aws-exports.json");
         const config = await response.json();
         if (config.IoTPolicy) {
           await attachIoTPolicy(config.IoTPolicy);
+        }
+
+        try {
+          const userAttributesOutput = await fetchUserAttributes();
+          setEmail(userAttributesOutput.email ?? null);
+        } catch (attrError) {
+          console.log("fetchUserAttributes failed (expected for federated users):", attrError);
         }
       } catch (e) {
         console.log(e);

--- a/source/webui/src/main.tsx
+++ b/source/webui/src/main.tsx
@@ -41,6 +41,17 @@ getRuntimeConfig().then((json) => {
         userPoolId: json.UserPoolId,
         userPoolClientId: json.PoolClientId,
         identityPoolId: json.IdentityPoolId,
+        ...(json.OAuthDomain && {
+          loginWith: {
+            oauth: {
+              domain: json.OAuthDomain,
+              scopes: ["email", "openid", "profile"],
+              redirectSignIn: [json.OAuthRedirectUrl],
+              redirectSignOut: [json.OAuthRedirectUrl],
+              responseType: "code",
+            },
+          },
+        }),
       },
     },
     API: {


### PR DESCRIPTION
When using an external OIDC identity provider (e.g., Microsoft Entra ID) federated through Amazon Cognito, three issues occur:

1. **No OAuth redirect** — The Amplify config doesn't include `loginWith.oauth`, so users see the default Cognito username/password form instead of being redirected to the external IdP.

2. **Random username displayed** — For federated users, Cognito auto-generates a username like `EntraID_SfmQzRfm...`. The top navigation bar shows this instead of the user's actual name.

3. **Real-time metrics broken** — `fetchUserAttributes()` fails for OIDC-federated users. Since the IoT policy attach runs after it in the same try block, it gets silently skipped, breaking the MQTT connection for live test metrics.

## Solution

**4 files changed, 43 insertions, 6 deletions. All changes are backward-compatible.**

### `source/infrastructure/lambda/aws-exports-handler/index.ts`
- Include `OAuthDomain` and `OAuthRedirectUrl` in `aws-exports.json` when provided by CloudFormation

### `source/webui/src/main.tsx`
- Conditionally add `loginWith.oauth` to the Amplify config when `OAuthDomain` is present

### `source/webui/src/components/navigation/TopNavigationBar.tsx`
- Read `name` (or `email`) from `idToken.payload` via `fetchAuthSession()` and display it, falling back to `user.username`

### `source/webui/src/contexts/UserContext.tsx`
- Move IoT policy attach **before** `fetchUserAttributes()`
- Wrap `fetchUserAttributes()` in its own try/catch so its failure doesn't block IoT setup

## Backward Compatibility

When `OAuthDomain` is not configured (no external IdP), all behavior is identical to the current implementation:
- OAuth config is only added conditionally
- Display name falls back to `user.username`
- IoT policy attach still runs in the same order relative to other operations