### PR TITLE
Update k6 from v1.5.0 to v2.0.0

### DIFF
--- a/k6.json
+++ b/k6.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "2.0.0",
   "download": {
     "binary": "https://github.com/grafana/k6/releases/download/v{version}/k6-v{version}-linux-{arch}.tar.gz",
     "checksums": "https://github.com/grafana/k6/releases/download/v{version}/k6-v{version}-checksums.txt"


### PR DESCRIPTION
## Summary
- Bump k6 from **v1.5.0** to **v2.0.0** (new major stable release) in `k6.json`, the single source of truth read at runtime by `deployment/ecr/distributed-load-testing-on-aws-load-tester/load-test.sh`.
- The download URL templates in `k6.json` are unchanged: the v2.0.0 release publishes the same asset naming the templates already expect.

## Verification
- Confirmed the resolved download URLs return HTTP 200:
  - `k6-v2.0.0-linux-amd64.tar.gz`
  - `k6-v2.0.0-linux-arm64.tar.gz`
  - `k6-v2.0.0-checksums.txt`
- Confirmed the checksums file lists both linux tarballs under the exact archive names `load-test.sh` greps for, so the download + checksum-validation + extraction flow works unchanged.
- Repo-wide search confirms the solution does **not** directly use any feature removed in k6 v2.0 (`externally-controlled` executor, `--no-summary`, `--summary-mode=legacy`, `k6 login`, `options.ext.loadimpact`, `k6/experimental/redis`, `K6_BINARY_PROVISIONING`, `K6_ENABLE_COMMUNITY_EXTENSIONS`).

## Notes
- CHANGELOG is intentionally left unchanged; following the existing convention, the k6 upgrade entry is added at release time (the v1.5.0 bump was recorded under `[4.0.7]`).
- k6 is invoked indirectly via Taurus (bzt). End-to-end validation of the bundled Taurus k6 executor against v2.0 is recommended before release — see issue #314 for the compatibility checklist.

## Test plan
- [ ] Build the load-tester container and run a k6 `.js` scenario (single file) end-to-end; confirm `kpi.csv` and `results.xml` are produced and parsed.
- [ ] Run a k6 `.ts` scenario and a zipped scenario.
- [ ] Verify on both `amd64` and `arm64` task architectures.

Closes #314